### PR TITLE
Update Ubuntu and puppet modules to current versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 group :development, :test do
+  gem 'librarian-puppet'
   gem 'rake'
   gem 'rspec'
   gem 'serverspec', '~> 1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,29 +1,70 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activemodel (4.1.7)
+      activesupport (= 4.1.7)
+      builder (~> 3.1)
+    activesupport (4.1.7)
+      i18n (~> 0.6, >= 0.6.9)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.1)
+      tzinfo (~> 1.1)
+    builder (3.2.2)
     diff-lcs (1.2.5)
+    faraday (0.9.0)
+      multipart-post (>= 1.2, < 3)
+    her (0.7.2)
+      activemodel (>= 3.0.0, < 4.2)
+      activesupport (>= 3.0.0, < 4.2)
+      faraday (>= 0.8, < 1.0)
+      multi_json (~> 1.7)
     highline (1.6.21)
-    net-ssh (2.8.0)
-    rake (10.2.2)
-    rspec (2.14.1)
-      rspec-core (~> 2.14.0)
-      rspec-expectations (~> 2.14.0)
-      rspec-mocks (~> 2.14.0)
-    rspec-core (2.14.8)
-    rspec-expectations (2.14.5)
+    i18n (0.6.11)
+    json (1.8.1)
+    librarian (0.1.2)
+      highline
+      thor (~> 0.15)
+    librarian-puppet (2.0.0)
+      librarian (>= 0.1.2)
+      puppet_forge
+      rsync
+    minitest (5.4.3)
+    multi_json (1.10.1)
+    multipart-post (2.0.0)
+    net-ssh (2.9.1)
+    puppet_forge (1.0.3)
+      her (~> 0.6)
+    rake (10.3.2)
+    rspec (2.99.0)
+      rspec-core (~> 2.99.0)
+      rspec-expectations (~> 2.99.0)
+      rspec-mocks (~> 2.99.0)
+    rspec-core (2.99.2)
+    rspec-expectations (2.99.2)
       diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.14.6)
-    serverspec (1.1.0)
+    rspec-its (1.0.1)
+      rspec-core (>= 2.99.0.beta1)
+      rspec-expectations (>= 2.99.0.beta1)
+    rspec-mocks (2.99.2)
+    rsync (1.0.9)
+    serverspec (1.16.0)
       highline
       net-ssh
-      rspec (~> 2.13)
-      specinfra (>= 1.0.0)
-    specinfra (1.0.3)
+      rspec (~> 2.99)
+      rspec-its
+      specinfra (~> 1.27)
+    specinfra (1.27.5)
+    thor (0.19.1)
+    thread_safe (0.3.4)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  librarian-puppet
   rake
   rspec
   serverspec (~> 1.1)

--- a/Modulefile
+++ b/Modulefile
@@ -3,6 +3,6 @@ version '0.0.1'
 description 'Install and manage Arcanist, part of Phabricator <http://phabricator.org/>'
 author 'Phil Frost <phil@macprofessionals.com>'
 
-dependency 'puppetlabs/stdlib', '3.x'
-dependency 'puppetlabs/vcsrepo', '0.x'
+dependency 'puppetlabs/stdlib', '>=3.0.0 <5.0.0'
+dependency 'puppetlabs/vcsrepo', '<2.0.0'
 dependency 'puppetlabs/git', '0.x'

--- a/Puppetfile
+++ b/Puppetfile
@@ -1,3 +1,3 @@
-forge "http://forge.puppetlabs.com"
+forge "https://forgeapi.puppetlabs.com"
 
 modulefile

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -1,12 +1,13 @@
 FORGE
-  remote: http://forge.puppetlabs.com
+  remote: https://forgeapi.puppetlabs.com
   specs:
-    puppetlabs/git (0.0.3)
-    puppetlabs/stdlib (3.2.1)
-    puppetlabs/vcsrepo (0.2.0)
+    puppetlabs-git (0.2.0)
+      puppetlabs-vcsrepo (>= 0.1.0)
+    puppetlabs-stdlib (4.4.0)
+    puppetlabs-vcsrepo (1.2.0)
 
 DEPENDENCIES
-  puppetlabs/git (~> 0.0)
-  puppetlabs/stdlib (~> 3.0)
-  puppetlabs/vcsrepo (~> 0.0)
+  puppetlabs-git (~> 0.0)
+  puppetlabs-stdlib (< 5.0.0, >= 3.0.0)
+  puppetlabs-vcsrepo (< 2.0.0)
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,15 +1,19 @@
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu-server-1310-x64-virtualbox"
-  config.vm.box_url = "http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-1310-x64-virtualbox-puppet.box"
+  config.vm.box = "ubuntu/trusty64"
 
-  config.vm.provision "shell", inline: <<-EOS
-    apt-get -qq update
-    apt-get install -y git ruby-dev build-essential libxml2-dev libxslt1-dev
-    gem install --no-ri --no-rdoc librarian-puppet bundler
+  config.vm.provision "shell", privileged: false, inline: <<-EOS
+    set -e -x
+    sudo apt-get -qq update
+    sudo apt-get install -y git ruby-dev build-essential libxml2-dev libxslt1-dev
+    sudo gem install --no-ri --no-rdoc bundler
     mkdir -p /usr/share/puppet/modules
+    sudo chown vagrant /usr/share/puppet/modules
     [ ! -e /usr/share/puppet/modules/arcanist ] && ln -s /vagrant /usr/share/puppet/modules/arcanist
-    (cd /usr/share/puppet/modules/arcanist && librarian-puppet install --path /usr/share/puppet/modules)
-    (cd /vagrant && bundle)
-    touch /etc/puppet/hiera.yaml
+    (
+      cd /vagrant
+      bundle
+      bundle exec librarian-puppet install --path /usr/share/puppet/modules
+    )
+    sudo touch /etc/puppet/hiera.yaml
   EOS
 end


### PR DESCRIPTION
The puppetlabs Ubuntu precise Vagrant box no longer passes the tests because
puppet has moved their apt repos, and dependencies on ancient stdlib and
vcsrepo puppet modules conflict with requirements of most other puppet modules.